### PR TITLE
fix: reflect changes on (un)install

### DIFF
--- a/src/plugin-store-item.svelte
+++ b/src/plugin-store-item.svelte
@@ -2,23 +2,7 @@
 import Menu from "@smui/menu";
 import { Button, SplitButton } from "./components/button";
 import List, { Item, Text } from "@smui/list";
-
-type PluginKind = "editor" | "menu" | "validator";
-const menuPosition = ["top", "middle", "bottom"] as const;
-type MenuPosition = (typeof menuPosition)[number];
-
-type Plugin = {
-	name: string;
-	author?: string;
-	src: string;
-	icon?: string;
-	kind: PluginKind;
-	requireDoc?: boolean;
-	position?: MenuPosition;
-	installed: boolean;
-	official?: boolean;
-	description?: string;
-};
+import { getStoredPlugins, type Plugin, type PluginKind } from "./plugin-store";
 
 type ConfigurePluginDetail = {
 	name: string;
@@ -32,7 +16,6 @@ export let filteredPlugins: Plugin[];
 export let pluginStore: Element;
 export let plugin: Plugin;
 export let index: number;
-export let storedPlugins: Plugin[];
 export let localPlugins: Plugin[];
 
 function dispatchConfigurePlugin(plugin: Plugin, shouldDelete = false) {
@@ -53,13 +36,13 @@ function dispatchConfigurePlugin(plugin: Plugin, shouldDelete = false) {
 }
 
 function installExternalPlugin(plugin: Plugin) {
-	const currentPlugins = storedPlugins;
+	const currentPlugins = getStoredPlugins();
 
 	const pluginCopy = { ...plugin };
 	pluginCopy.installed = true;
 	currentPlugins.push(pluginCopy);
 
-	localPlugins = currentPlugins;
+	localPlugins = currentPlugins; 
 
 	dispatchConfigurePlugin(pluginCopy);
 	console.log("Installed external plugin:", plugin.name);
@@ -67,7 +50,7 @@ function installExternalPlugin(plugin: Plugin) {
 
 // Completely removes plugin from local browser cache.
 function uninstallExternalPlugin(plugin: Plugin) {
-	const currentPlugins = storedPlugins;
+	const currentPlugins = getStoredPlugins();
 	const updatedPlugins = currentPlugins.filter((it) => it.name !== plugin.name);
 	localPlugins = updatedPlugins;
 
@@ -77,7 +60,7 @@ function uninstallExternalPlugin(plugin: Plugin) {
 
 // Enables/disables plugin by toggling the "installed" property.
 function toggleOfficialPlugin(plugin: Plugin, isEnabled: boolean) {
-	const currentPlugins = storedPlugins;
+	const currentPlugins = getStoredPlugins();
 	const foundPlugin = currentPlugins.find((it) => it.name === plugin.name);
 	if (foundPlugin) {
 		foundPlugin.installed = isEnabled;

--- a/src/plugin-store.svelte
+++ b/src/plugin-store.svelte
@@ -9,35 +9,12 @@ import IconButton from "@smui/icon-button";
 import Dialog, { Header, Title, Content, Actions } from "@smui/dialog";
 import { plugins as externalPlugins } from "../public/plugins.json";
 import PluginStoreItem from "./plugin-store-item.svelte";
+import type { Plugin } from "./plugin-store";
+import { getStoredPlugins as storedPlugins } from "./plugin-store";
 
 const isRestricted = !import.meta.env.VITE_EXTERNAL_PLUGINS === true;
 
 export let isOpen: boolean;
-
-// #region Plugin
-
-type PluginKind = "editor" | "menu" | "validator";
-const menuPosition = ["top", "middle", "bottom"] as const;
-type MenuPosition = (typeof menuPosition)[number];
-
-type Plugin = {
-	name: string;
-	author?: string;
-	src: string;
-	icon?: string;
-	kind: PluginKind;
-	requireDoc?: boolean;
-	position?: MenuPosition;
-	installed: boolean;
-	official?: boolean;
-	description?: string;
-};
-
-function storedPlugins(): Plugin[] {
-	return <Plugin[]>(
-		JSON.parse(localStorage.getItem("plugins") ?? "[]", (key, value) => value)
-	);
-}
 
 let showOnlyInstalled = false;
 let searchFilter = "";
@@ -97,12 +74,8 @@ $: editorPlugins = filteredPlugins.filter((it) => it.kind === "editor");
 $: menuPlugins = filteredPlugins.filter((it) => it.kind === "menu");
 $: validatorPlugins = filteredPlugins.filter((it) => it.kind === "validator");
 
-// #endregion
-
-// #region UI
 let pluginStore: Element;
 
-// #endregion
 </script>
 
 <Theme>
@@ -147,7 +120,6 @@ let pluginStore: Element;
                          plugin={plugin}
                          index={index}
                          filteredPlugins={filteredPlugins} 
-                         storedPlugins={storedPlugins()} 
                          bind:localPlugins={localPlugins} 
                          pluginStore={pluginStore}/> 
                     {/each}
@@ -165,8 +137,7 @@ let pluginStore: Element;
                          plugin={plugin}
                          index={index}
                          filteredPlugins={filteredPlugins} 
-                         storedPlugins={storedPlugins()} 
-                         localPlugins={localPlugins} 
+                         bind:localPlugins={localPlugins} 
                          pluginStore={pluginStore}/> 
                     {/each}
                     {#if menuPlugins.length === 0}
@@ -183,8 +154,7 @@ let pluginStore: Element;
                          plugin={plugin}
                          index={index}
                          filteredPlugins={filteredPlugins} 
-                         storedPlugins={storedPlugins()} 
-                         localPlugins={localPlugins} 
+                         bind:localPlugins={localPlugins} 
                          pluginStore={pluginStore}/> 
                     {/each}
                     {#if validatorPlugins.length === 0}

--- a/src/plugin-store.ts
+++ b/src/plugin-store.ts
@@ -1,0 +1,22 @@
+export type Plugin = {
+	name: string;
+	author?: string;
+	src: string;
+	icon?: string;
+	kind: PluginKind;
+	requireDoc?: boolean;
+	position?: MenuPosition;
+	installed: boolean;
+	official?: boolean;
+	description?: string;
+};
+
+const menuPosition = ["top", "middle", "bottom"] as const;
+export type PluginKind = "editor" | "menu" | "validator";
+export type MenuPosition = (typeof menuPosition)[number];
+
+export function getStoredPlugins(): Plugin[] {
+    return <Plugin[]>(
+		JSON.parse(localStorage.getItem("plugins") ?? "[]", (key, value) => value)
+	);
+}


### PR DESCRIPTION
When uninstalling and installing a plugin, the entry would get shown twice in list due to outdated state variable. It's gone after refreshing the browser. 

This PR fixes this by moving functions and types used in both `.svelte` files into its own `.ts` file to ensure both can access the latest localStorage content.

Resolves #28 